### PR TITLE
Fix comment deletion bug

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 

--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,7 +362,6 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
-    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Resolves https://github.com/CMU-313/CMU-313-fall23-sw-archaeology-recitation/issues/1, where an admin could not delete a comment. Fixed by committing the change after a user has signaled to delete a comment.