### PR TITLE
Fixed Comment Delete Bug

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -361,6 +361,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Fixed Issues #1  
Fixed the bug. Am able to create my own comment and then delete my own comment. I found the bug by searching for delete/comment which brought me to the main.py. I saw that there was only db.session.delete(comment) and not a line to actually commit the change.
I added db.session.commit() to line 364 of main.py file