### PR TITLE
Fixed comment not deleting. Comment now properly deletes

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Added db.commit() after db.delete(comment) to update the delete to the system.

Fixes comment deletion bug #1 