### PR TITLE
Fix delete comment issue

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Fix issue that deleting a comment does not work. Now, once delete is clicked, the comment is successfully deleted from the post.

Resolves https://github.com/CMU-313/CMU-313-fall23-sw-archaeology-recitation/issues/1