### PR TITLE
Fixing deleting comments

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION

Resolves https://github.com/CMU-313/CMU-313-fall23-sw-archaeology-recitation/issues/1 

Added in db.session.commit() so when a comment is deleted it is saved fixing the bug.