### PR TITLE
fixed delete comment bug

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Changes Made:
- In albumy/blueprints/main.py I added the line db.session.commit() after db.session.delete(comment). This line makes sure that the view is updated and the deleted comment disappears.

Testing:
- I tested it manually by deleting the comment in the browser