### PR TITLE
Fix comment deletion

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Comments previously were not being deleted because after deletion in the DB, we'd return without actually committing the changes. Now, we commit the changes, and so it should actually work.

Resolves https://github.com/CMU-313/CMU-313-fall23-sw-archaeology-recitation/issues/1