### PR TITLE
Fixed delete_comment by committing db change

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -358,10 +358,12 @@ def delete_photo(photo_id):
 @login_required
 def delete_comment(comment_id):
     comment = Comment.query.get_or_404(comment_id)
+    print(current_user, comment.author)
     if current_user != comment.author and current_user != comment.photo.author \
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Addresses #1 

Added a line `db.session.commit()` in the `delete_comment()` function to commit the changes that were staged by the comment delete action. Comments can now be properly deleted.